### PR TITLE
First implementation of ziffect.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.ropeproject/
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "nightly" # currently points to 3.6-dev
+# command to install dependencies
+install: "pip install -r dev-requirements.txt"
+# command to run tests
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+
+
+test:
+	nosetests --nocapture ziffect/tests/basic_usage.py

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,15 @@
+attrs==15.2.0
+effect==0.10.1
+extras==0.0.3
+funcsigs==0.4
+linecache2==1.0.0
+nose==1.3.7
+pbr==1.8.1
+pyrsistent==0.11.10
+python-mimeparse==0.1.4
+six==1.10.0
+testtools==1.8.1
+traceback2==1.4.0
+unittest2==1.1.0
+wheel==0.24.0
+zope.interface==4.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+attrs==15.2.0
+effect==0.10.1
+funcsigs==0.4
+pyrsistent==0.11.10
+six==1.10.0
+wheel==0.24.0
+zope.interface==4.1.3

--- a/ziffect/__init__.py
+++ b/ziffect/__init__.py
@@ -1,0 +1,233 @@
+
+from __future__ import unicode_literals
+
+from effect import TypeDispatcher, Effect, sync_performer
+from pyrsistent import PClass, field, PClassMeta
+from six import add_metaclass, iteritems
+from testtools.matchers import Not, Is
+from funcsigs import signature
+
+__all__ = [
+    'interface',
+    'effects',
+    'matchers',
+    'argument'
+]
+
+
+class _matchers(object):
+    """
+    Hack implementation of the ziffect matchers.
+
+    Will be replaced by proper module.
+    """
+
+    def Provides(self, interface):
+        """
+        Matches if interface is provided by the matchee.
+        """
+        return Not(Is(None))
+
+matchers = _matchers()
+
+
+class argument(PClass):
+    type = field(type=type)
+
+
+def _make_intent_from_args(args):
+    """
+    Create an intent type for a given set of arguments.
+
+    :param args: a dict with keys as the names of arguments and values as
+        :class:`argument`s.
+
+    :returns: A new type that can hold all of the data to call a function that
+        has the given arguments.
+    """
+    class _Intent(PClass):
+        pass
+
+    for name, arg in iteritems(args):
+        setattr(_Intent, name, field(type=arg.type))
+
+    _PIntent = add_metaclass(PClassMeta)(_Intent)
+
+    return _PIntent
+
+
+def _iterate_methods(interface):
+    """
+    A generator to iterate over the methods of an interface.
+
+    :param interface: A ziffect interface.
+
+    :yields: names of methods.
+    """
+    for operator_name in dir(interface):
+        if not operator_name.startswith('_'):
+            yield operator_name
+
+
+def _get_method_argspecs(interface):
+    """
+    A generator to get the argspecs of methods on an interface.
+
+    :param interface: The ziffect interface to inspect.
+
+    :yields: tuples of method name and dictionaries that map name of
+        argument to :class:`argument` instances.
+    """
+    for method_name in _iterate_methods(interface):
+        method = getattr(interface, method_name)
+        sig = signature(method)
+        args = dict(
+            (name, arg.default)
+            for name, arg in iteritems(sig.parameters)
+        )
+        yield method_name, args
+
+
+def _make_intents(argspecs):
+    """
+    Constructs intents for each of the argspecs passed in.
+
+    :param argspecs: A dict with keys as method names, and values as
+        dicts that map name of argument to :class:`argument` instances.
+
+    :return: dict that maps method_name to intent class.
+    """
+    return dict(
+     (method_name, _make_intent_from_args(args))
+     for method_name, args in iteritems(argspecs)
+    )
+
+
+def _make_effect_method(intent):
+    """
+    Turn an intent into a method that creates an effect.
+
+    :param intent: The class for the intent.
+
+    :returns Effect: An effect that describes the given intent.
+    """
+    def _method(self, **kwargs):
+        return Effect(intent(**kwargs))
+    return _method
+
+
+def _make_effects(intents):
+    """
+    Creates a class that has methods that generate effects for the given
+    intents.
+
+    :param intents: dict mapping names of intents to their classes.
+
+    :returns: A new class with method names equal to the keys of the input.
+        Each method on this class will generate an Effect for use with the
+        Effect library.
+    """
+    class _Effects(object):
+        pass
+
+    for method_name, intent in iteritems(intents):
+        method = _make_effect_method(intent)
+        setattr(_Effects, method_name, method)
+
+    return _Effects()
+
+
+def interface(wrapped_class):
+    """
+    Class decorator to wrap ziffect interfaces.
+
+    :param wrapped_class: The class to wrap.
+
+    :returns: The newly created wrapped class.
+    """
+    wrapped_class._ziffect_argspecs = dict(
+        (key, value)
+        for key, value in _get_method_argspecs(wrapped_class)
+    )
+    wrapped_class._ziffect_intents = _make_intents(
+        wrapped_class._ziffect_argspecs)
+    wrapped_class._ziffect_effects = _make_effects(
+        wrapped_class._ziffect_intents)
+    return wrapped_class
+
+
+def effects(interface):
+    """
+    Method to get an object that implements interface by just returning effects
+    for each method call.
+
+    :param interface: The interface for which to create a provider.
+
+    :returns: A class with method names equal to the method names of the
+        interface. Each method on this class will generate an Effect for use
+        with the Effect library.
+    """
+    return interface._ziffect_effects
+
+
+def implements(interface):
+    """
+    Class decorator to indicate that wrapped_class implements the interface.
+
+    :param interface: The interface that is implemented by the class.
+
+    :returns: decorator for the wrapped class.
+    """
+    def _implements_decorator(wrapped_class):
+        return wrapped_class
+    return _implements_decorator
+
+
+def _make_performer(method, arg_keys):
+    """
+    Constructs a performer for that calls a specific method. This involves
+    unpacking the intent into keyword arguments for the method.
+
+    Note that this presently does not pass the dispatcher down to the
+    underlying method. Thus, ziffect interface implementations presently cannot
+    perform other effects that have side effects.
+
+    :param method: The underlying method to call. Should be a method bound to
+        an object that provides a ziffect interface.
+    :param arg_keys: Iterable of strings that are both the keyword arguments of
+        the method and the names of the attributes of the intent.
+
+    :returns: An Effect performer that calls method with the arguments in the
+        intent.
+    """
+    @sync_performer
+    def _perform(dispatcher, intent):
+        args = dict(
+            (k, getattr(intent, k))
+            for k in arg_keys
+        )
+        return method(**args)
+    return _perform
+
+
+def dispatcher(interface_map):
+    """
+    Creates a dispatcher for a number of interfaces.
+
+    :param interface_map: A map from ziffect interface to a provider of the
+        interface.
+
+    :returns: An Effect dispatcher that will use the passed in interfaces to
+        perform Effects that have been generated from the
+        ``ziffect.effect(interface).method()`` implementation.
+    """
+    typemap = {}
+    for interface, provider in iteritems(interface_map):
+        intents = interface._ziffect_intents
+        argspecs = interface._ziffect_argspecs
+        for method_name in _iterate_methods(interface):
+            method = getattr(provider, method_name)
+            intent = intents[method_name]
+            typemap[intent] = _make_performer(method,
+                                              argspecs[method_name].keys())
+    return TypeDispatcher(typemap)

--- a/ziffect/tests/basic_usage.py
+++ b/ziffect/tests/basic_usage.py
@@ -1,0 +1,82 @@
+
+from __future__ import unicode_literals
+
+from testtools import TestCase
+from testtools.matchers import Equals
+from six import text_type
+from effect import sync_perform
+
+import ziffect
+
+
+@ziffect.interface
+class Utils(object):
+    """
+    Lets pretend we have a ``Utils`` interface.
+    """
+
+    def add(operator_a=ziffect.argument(type=int),
+            operator_b=ziffect.argument(type=int)):
+        """
+        The add method does some sort of action on two ints.
+        """
+        pass
+
+    def concat(operator_a=ziffect.argument(type=text_type),
+               operator_b=ziffect.argument(type=text_type)):
+        """
+        The concat method does some sort of action on two text arguments.
+        """
+        pass
+
+
+@ziffect.implements(Utils)
+class RecordCallsUtils(object):
+    """
+    Implementation of Utils interface that
+    """
+    def __init__(self):
+        self.calls = dict(
+            add=[],
+            concat=[]
+        )
+
+    def add(self, operator_a, operator_b):
+        self.calls['add'].append((operator_a, operator_b))
+
+    def concat(self, operator_a, operator_b):
+        self.calls['concat'].append((operator_a, operator_b))
+
+
+class BasicUsage(TestCase):
+    """
+    Tests for the simple use cases of this library.
+    """
+
+    def test_basic_usage(self):
+        """
+        Using an implementation of a ziffect interface that
+        """
+        utils_effects = ziffect.effects(Utils)
+        my_call_logger = RecordCallsUtils()
+
+        self.expectThat(my_call_logger, ziffect.matchers.Provides(Utils))
+
+        dispatcher = ziffect.dispatcher({
+            Utils: my_call_logger
+        })
+
+        sync_perform(
+            dispatcher,
+            utils_effects.add(operator_a=12, operator_b=23)
+        )
+        self.expectThat(
+            my_call_logger.calls['add'], Equals([(12, 23)]))
+
+        sync_perform(
+            dispatcher,
+            utils_effects.concat(operator_a='me', operator_b='ow')
+        )
+        self.expectThat(
+            my_call_logger.calls['concat'], Equals([('me', 'ow')])
+        )


### PR DESCRIPTION
ziffect is a new library intended to provide some glue layers between zope
interfaces and Effect. It occurred to me while working with Effect that Effect
dispatchers are effectively classes, the types that they dispatch based upon
are effectively names of methods, and intents are effectively bundles of
arguments.

This is a first-pass proof of concept, that definitely took some shortcuts and
only implements the happy path for now. Future work will include tests for good
exceptions and actual attempts to use ziffect for something significant to see
if it is useful or not.
